### PR TITLE
Non pixel units

### DIFF
--- a/packages/core/src/_typography.scss
+++ b/packages/core/src/_typography.scss
@@ -37,7 +37,7 @@ $headings: (
   "h4": (18px, 21px),
   "h5": (16px, 19px),
   "h6": (14px, 16px)
-);
+) !default;
 
 @each $tag, $props in $headings {
   %#{$tag} {
@@ -261,7 +261,7 @@ Styleguide preformatted
   border-radius: $pt-border-radius;
   box-shadow: inset border-shadow(0.2);
   background: $pt-code-background-color;
-  padding: 2px 5px;
+  padding: ($pt-grid-size / 4) ($pt-grid-size / 2);
   color: $pt-code-text-color;
   font-size: smaller;
 
@@ -293,7 +293,7 @@ Styleguide preformatted
   padding: ($pt-grid-size * 1.3) ($pt-grid-size * 1.5) ($pt-grid-size * 1.2);
   line-height: 1.4;
   color: $pt-text-color;
-  font-size: $pt-font-size - 1px;
+  font-size: ($pt-font-size + $pt-font-size-small) / 2;
   word-break: break-all;
   word-wrap: break-word;
 

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -85,12 +85,12 @@ Styleguide breadcrumbs
 }
 
 .#{$ns}-breadcrumbs-collapsed {
-  margin-right: 2px;
+  margin-right: $pt-grid-size / 4;
   border: none;
   border-radius: $pt-border-radius;
   background: $light-gray1;
   cursor: pointer;
-  padding: 1px ($pt-grid-size / 2);
+  padding: ($pt-grid-size / 8) ($pt-grid-size / 2);
   vertical-align: text-bottom;
 
   &::before {

--- a/packages/core/src/components/forms/_controls.scss
+++ b/packages/core/src/components/forms/_controls.scss
@@ -116,7 +116,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   .#{$ns}-control-indicator {
     display: inline-block;
     position: relative;
-    margin-top: -3px;
+    margin-top: -1 * ($pt-line-height * $pt-font-size - $pt-font-size) / 2;
     margin-right: $control-indicator-spacing;
     border: none;
     box-shadow: $button-box-shadow;
@@ -162,7 +162,7 @@ $control-indicator-spacing: $pt-grid-size !default;
   // right-aligned indicator is glued to the right side of the container
   &.#{$ns}-align-right .#{$ns}-control-indicator {
     float: right;
-    margin-top: 1px;
+    margin-top: ($pt-line-height * $pt-font-size - $pt-font-size) / 2;
     margin-left: $control-indicator-spacing;
   }
 
@@ -282,7 +282,7 @@ $control-indicator-spacing: $pt-grid-size !default;
 
   // stylelint-disable-next-line order/order
   $switch-width: 1.75em !default;
-  $switch-indicator-margin: 2px !default;
+  $switch-indicator-margin: $pt-grid-size / 4 !default;
   $switch-indicator-size: calc(1em - #{$switch-indicator-margin * 2});
 
   $switch-background-color: rgba($gray4, 0.5) !default;

--- a/packages/core/src/components/menu/_common.scss
+++ b/packages/core/src/components/menu/_common.scss
@@ -154,9 +154,9 @@ $dark-menu-item-color-active: $dark-minimal-button-background-color-active !defa
   @include heading-typography();
   @include overflow-ellipsis();
   margin: 0;
-  padding: $pt-grid-size $menu-item-padding 0 1px;
-  // a little extra space to avoid clipping descenders (because overflow hidden)
-  line-height: $pt-icon-size-standard + 1px;
+  padding: $pt-grid-size $menu-item-padding 0 0;
+  // use menu item line-height to avoid clipping descenders (because overflow hidden)
+  line-height: $menu-item-line-height;
 }
 
 @mixin menu-header-large($heading-selector) {

--- a/packages/core/src/components/panel-stack/_panel-stack.scss
+++ b/packages/core/src/components/panel-stack/_panel-stack.scss
@@ -39,7 +39,7 @@
 
   .#{$ns}-icon {
     // reduce margins around icon so it fits better in tight header
-    margin: 0 2px;
+    margin: 0 ($pt-grid-size / 4);
   }
 }
 

--- a/packages/core/src/components/popover/_popover.scss
+++ b/packages/core/src/components/popover/_popover.scss
@@ -3,13 +3,16 @@
 
 @import "./common";
 
+$popover-arrow-square-size: $pt-grid-size * 3 !default;
+$popover-arrow-offset: $pt-grid-size / 2 !default;
+$popover-arrow-target-offset: -1 * $popover-arrow-offset !default;
 $popover-width: $pt-grid-size * 35 !default;
 
 .#{$ns}-popover {
   @include popover-sizing(
-    $arrow-square-size: 30px,
-    $arrow-offset: 4px,
-    $arrow-target-offset: -4px
+    $arrow-square-size: $popover-arrow-square-size,
+    $arrow-offset: $popover-arrow-offset,
+    $arrow-target-offset: $popover-arrow-target-offset
   );
   @include popover-appearance(
     $popover-background-color,

--- a/packages/core/src/components/slider/_slider.scss
+++ b/packages/core/src/components/slider/_slider.scss
@@ -6,7 +6,7 @@
 
 $handle-size: $pt-icon-size-standard !default;
 $track-size: $handle-size - $pt-grid-size !default;
-$label-offset: $handle-size + 4px !default;
+$label-offset: $handle-size + ($pt-grid-size / 2) !default;
 
 // retain legacy variable aliases so as to not break consumers
 $handle-height: $handle-size !default;

--- a/packages/core/src/components/tag/_common.scss
+++ b/packages/core/src/components/tag/_common.scss
@@ -14,10 +14,10 @@ $tag-height-large: $pt-grid-size * 3 !default;
 $tag-line-height-large: $pt-icon-size-large !default;
 $tag-padding-large: ($tag-height-large - $tag-line-height-large) !default;
 
-$tag-icon-spacing: ($tag-height - 12px) / 2 !default;
+$tag-icon-spacing: ($tag-height - $pt-icon-size-standard) !default;
 $tag-icon-spacing-large: ($tag-height-large - $pt-icon-size-standard) / 2 !default;
 
-$tag-round-adjustment: 2px !default;
+$tag-round-adjustment: $pt-grid-size / 4 !default;
 
 @mixin pt-tag() {
   @include pt-tag-interactive($tag-default-color, 1);

--- a/packages/core/src/components/tooltip/_tooltip.scss
+++ b/packages/core/src/components/tooltip/_tooltip.scss
@@ -5,11 +5,15 @@
 @import "../popover/common";
 @import "./common";
 
+$tooltip-arrow-square-size: $pt-grid-size * 2 !default;
+$tooltip-arrow-offset: $pt-grid-size / 4 !default;
+$tooltip-arrow-target-offset: -1 * $tooltip-arrow-offset !default;
+
 .#{$ns}-tooltip {
   @include popover-sizing(
-    $arrow-square-size: 22px,
-    $arrow-offset: 3px,
-    $arrow-target-offset: -4px
+    $arrow-square-size: $tooltip-arrow-square-size,
+    $arrow-offset: $tooltip-arrow-offset,
+    $arrow-target-offset: $tooltip-arrow-target-offset
   );
   @include popover-appearance(
     $tooltip-background-color,

--- a/packages/datetime/src/common/months.ts
+++ b/packages/datetime/src/common/months.ts
@@ -10,7 +10,7 @@
  * Note that the enum values are numbers (with January as `0`) so they can be
  * easily compared to `date.getMonth()`.
  */
-export const enum Months {
+export enum Months {
     JANUARY = 0,
     FEBRUARY = 1,
     MARCH = 2,

--- a/packages/select/src/components/query-list/queryList.tsx
+++ b/packages/select/src/components/query-list/queryList.tsx
@@ -136,7 +136,7 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
             this.setState({ activeItem: nextProps.activeItem });
         }
         if (nextProps.query != null) {
-            this.setQuery(nextProps.query);
+            this.setQuery(nextProps.query, nextProps.resetOnQuery, nextProps);
         }
     }
 
@@ -192,14 +192,14 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         }
     }
 
-    public setQuery(query: string, resetActiveItem = this.props.resetOnQuery) {
+    public setQuery(query: string, resetActiveItem = this.props.resetOnQuery, props = this.props) {
         this.shouldCheckActiveItemInViewport = true;
         const hasQueryChanged = query !== this.state.query;
         if (hasQueryChanged) {
-            Utils.safeInvoke(this.props.onQueryChange, query);
+            Utils.safeInvoke(props.onQueryChange, query);
         }
 
-        const filteredItems = getFilteredItems(query, this.props);
+        const filteredItems = getFilteredItems(query, props);
         this.setState({ filteredItems, query });
 
         // always reset active item if it's now filtered or disabled
@@ -207,10 +207,10 @@ export class QueryList<T> extends React.Component<IQueryListProps<T>, IQueryList
         const shouldUpdateActiveItem =
             resetActiveItem ||
             activeIndex < 0 ||
-            isItemDisabled(this.state.activeItem, activeIndex, this.props.itemDisabled);
+            isItemDisabled(this.state.activeItem, activeIndex, props.itemDisabled);
 
         if (hasQueryChanged && shouldUpdateActiveItem) {
-            this.setActiveItem(getFirstEnabledItem(filteredItems, this.props.itemDisabled));
+            this.setActiveItem(getFirstEnabledItem(filteredItems, props.itemDisabled));
         }
     }
 

--- a/packages/select/test/queryListTests.tsx
+++ b/packages/select/test/queryListTests.tsx
@@ -3,7 +3,6 @@
  *
  * Licensed under the terms of the LICENSE file distributed with this project.
  */
-
 import { assert } from "chai";
 import { mount, ReactWrapper, shallow } from "enzyme";
 import * as React from "react";
@@ -12,7 +11,7 @@ import * as sinon from "sinon";
 // this is an awkward import across the monorepo, but we'd rather not introduce a cyclical dependency or create another package
 import { IQueryListProps } from "@blueprintjs/select";
 import { IFilm, renderFilm, TOP_100_FILMS } from "../../docs-app/src/examples/select-examples/films";
-import { IQueryListRendererProps, ItemListPredicate, ItemListRenderer, QueryList } from "../src/index";
+import { IQueryListRendererProps, IQueryListState, ItemListPredicate, ItemListRenderer, QueryList } from "../src/index";
 
 describe("<QueryList>", () => {
     const FilmQueryList = QueryList.ofType<IFilm>();
@@ -103,6 +102,23 @@ describe("<QueryList>", () => {
             const filmQueryList: ReactWrapper<IQueryListProps<IFilm>> = mount(<FilmQueryList {...props} />);
             filmQueryList.setProps(props);
             assert.equal(testProps.onActiveItemChange.callCount, 0);
+        });
+
+        it("ensure activeItem changes on query change", () => {
+            const props: IQueryListProps<IFilm> = {
+                ...testProps,
+                items: [TOP_100_FILMS[0]],
+                query: "abc",
+            };
+            const filmQueryList: ReactWrapper<IQueryListProps<IFilm>, IQueryListState<IFilm>> = mount(
+                <FilmQueryList {...props} />,
+            );
+            assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[0]);
+            filmQueryList.setProps({
+                items: [TOP_100_FILMS[1]],
+                query: "123",
+            });
+            assert.deepEqual(filmQueryList.state().activeItem, TOP_100_FILMS[1]);
         });
     });
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Fixes the lack of `!default` on the `$headings` variable so the values can be overridden.
- Allows the usage of non-pixel units on such variables as `$pt-font-size` and `$pt-grid-unit`.
    - Finds places in the code where mixing units would throw an error.
    - Eliminates some magic-looking numbers and replaces with values calculated from variables.
    - Exposes popover and tooltip arrow variables
- Includes latest commits from upstream
